### PR TITLE
Memorious operation

### DIFF
--- a/alephclient/cli.py
+++ b/alephclient/cli.py
@@ -2,6 +2,7 @@ import json
 import click
 import logging
 
+from alephclient import settings
 from alephclient.api import AlephAPI
 from alephclient.errors import AlephException
 from alephclient.tasks.crawldir import crawl_dir
@@ -12,26 +13,25 @@ log = logging.getLogger(__name__)
 
 
 @click.group()
-@click.option('--api-base-url', help="Aleph API address", envvar="ALEPH_HOST")
-@click.option("--api-key", envvar="ALEPH_API_KEY", help="Aleph API key for authentication")  # noqa
+@click.option('--host', default=settings.ALEPH_HOST, metavar="URL", help="Aleph API URL")  # noqa
+@click.option('--api-key', default=settings.ALEPH_API_KEY, metavar="KEY", help="Aleph API key for authentication")  # noqa
 @click.option('-r', '--retries', type=int, default=5, help="retries upon server failure")  # noqa
 @click.pass_context
-def cli(ctx, api_base_url, api_key, retries):
+def cli(ctx, host, api_key, retries):
     """API client for Aleph API"""
     logging.basicConfig(level=logging.DEBUG)
     logging.getLogger('requests').setLevel(logging.WARNING)
     logging.getLogger('urllib3').setLevel(logging.WARNING)
     logging.getLogger('httpstream').setLevel(logging.WARNING)
-    if not api_base_url:
-        raise click.BadParameter("Missing Aleph base URL")
+    if not host:
+        raise click.BadParameter('Missing Aleph host URL')
     if ctx.obj is None:
         ctx.obj = {}
-    ctx.obj["api"] = AlephAPI(api_base_url, api_key, retries=retries)
+    ctx.obj['api'] = AlephAPI(host, api_key, retries=retries)
 
 
 @cli.command()
-@click.option('--casefile', is_flag=True, default=False,
-              help="handle as case file")
+@click.option('--casefile', is_flag=True, default=False, help='handle as case file')  # noqa
 @click.option('--language',
               multiple=True,
               help="language hint: 2-letter language code (ISO 639)")

--- a/alephclient/memorious.py
+++ b/alephclient/memorious.py
@@ -56,8 +56,8 @@ def aleph_emit(context, data):
         file_path = Path(fh.name).resolve()
         res = api.ingest_upload(collection_id, file_path, meta)
         if res.get('status') == 'ok':
-            document = res.get('documents')[0]
-            context.log.info("Document ID: %s", document['id'])
+            document = res.get('id')
+            context.log.info("Document ID: %s", document)
         else:
             context.emit_warning("Error: %r" % res)
 

--- a/alephclient/memorious.py
+++ b/alephclient/memorious.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+from pprint import pprint  # noqa
+from banal import clean_dict
+
+from alephclient import settings
+from alephclient.api import AlephAPI
+
+
+def aleph_emit(context, data):
+    api = get_api(context)
+    if api is None:
+        return
+    collection_id = get_collection_id(context, api)
+    if collection_id is None:
+        context.log.warning("Cannot get aleph collection.")
+        return
+
+    content_hash = data.get('content_hash')
+    source_url = data.get('source_url', data.get('url'))
+    foreign_id = data.get('foreign_id', data.get('request_id', source_url))
+    if context.skip_incremental(collection_id, foreign_id, content_hash):
+        context.log.info("Skip aleph upload: %s", foreign_id)
+        return
+
+    meta = {
+        'crawler': context.crawler.name,
+        'foreign_id': foreign_id,
+        'source_url': source_url,
+        'title': data.get('title'),
+        'author': data.get('author'),
+        'file_name': data.get('file_name'),
+        'retrieved_at': data.get('retrieved_at'),
+        'modified_at': data.get('modified_at'),
+        'published_at': data.get('published_at'),
+        'headers': data.get('headers', {})
+    }
+
+    languages = context.params.get('languages')
+    meta['languages'] = data.get('languages', languages)
+    countries = context.params.get('countries')
+    meta['countries'] = data.get('countries', countries)
+    mime_type = context.params.get('mime_type')
+    meta['mime_type'] = data.get('mime_type', mime_type)
+
+    if data.get('parent_foreign_id'):
+        meta['parent'] = {'foreign_id': data.get('parent_foreign_id')}
+
+    meta = clean_dict(meta)
+    # pprint(meta)
+
+    label = meta.get('file_name', meta.get('source_url'))
+    context.log.info("Upload: %s", label)
+    with context.load_file(content_hash) as fh:
+        if fh is None:
+            return
+        file_path = Path(fh.name).resolve()
+        res = api.ingest_upload(collection_id, file_path, meta)
+        if res.get('status') == 'ok':
+            document = res.get('documents')[0]
+            context.log.info("Document ID: %s", document['id'])
+        else:
+            context.emit_warning("Error: %r" % res)
+
+
+def get_api(context):
+    if not settings.ALEPH_HOST:
+        context.log.warning("No $MEMORIOUS_ALEPH_HOST, skipping upload...")
+        return
+    if not settings.ALEPH_API_KEY:
+        context.log.warning("No $MEMORIOUS_ALEPH_API_KEY, skipping upload...")
+        return
+
+    session_id = 'memorious:%s' % context.crawler.name
+    return AlephAPI(settings.ALEPH_HOST,
+                    settings.ALEPH_API_KEY,
+                    session_id=session_id)
+
+
+def get_collection_id(context, api):
+    if hasattr(context.stage, '_aleph_cid'):
+        return context.stage._aleph_cid
+    foreign_id = context.get('collection', context.crawler.name)
+    config = {'label': context.crawler.description}
+    collection = api.load_collection_by_foreign_id(foreign_id, config=config)
+    context.stage._aleph_cid = collection.get('id')
+    return context.stage._aleph_cid

--- a/alephclient/settings.py
+++ b/alephclient/settings.py
@@ -1,0 +1,8 @@
+import os
+
+# Aleph client API settings
+ALEPH_HOST = os.environ.get('MEMORIOUS_ALEPH_HOST')
+ALEPH_HOST = os.environ.get('ALEPH_HOST', ALEPH_HOST)
+
+ALEPH_API_KEY = os.environ.get('MEMORIOUS_ALEPH_API_KEY')
+ALEPH_API_KEY = os.environ.get('ALEPH_API_KEY', ALEPH_API_KEY)

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ setup(
     entry_points={
         'console_scripts': [
             'alephclient = alephclient.cli:cli'
+        ],
+        'memorious.operations': [
+            'aleph_emit = alephclient.memorious:aleph_emit',
         ]
     },
 )


### PR DESCRIPTION
This change creates a uniform way for the alephclient to read settings from the environment for both the alephclient CLI and the library version. 

It also moves the memorious operation over to alephclient, from memorious core software. This way, the operation will be visible in all memorious installs that have alephclient included, but memorious will not have to depend on alephclient any more. 

@sunu Can you do the opposing work on memorious next week?