### PR TITLE
Collection Deletion

### DIFF
--- a/alephclient/api.py
+++ b/alephclient/api.py
@@ -15,29 +15,28 @@ from alephclient.errors import AlephException
 from alephclient.util import backoff, prop_push
 
 log = logging.getLogger(__name__)
-MIME = 'application/octet-stream'
-VERSION = pkg_resources.get_distribution('alephclient').version
+MIME = "application/octet-stream"
+VERSION = pkg_resources.get_distribution("alephclient").version
 
 
 class APIResultSet(object):
-
-    def __init__(self, api: 'AlephAPI', url: str):
+    def __init__(self, api: "AlephAPI", url: str):
         self.api = api
         self.url = url
         self.current = 0
-        self.result = self.api._request('GET', self.url)
+        self.result = self.api._request("GET", self.url)
 
     def __iter__(self):
         return self
 
     def __next__(self):
-        if self.index >= self.result.get('limit'):
-            next_url = self.result.get('next')
+        if self.index >= self.result.get("limit"):
+            next_url = self.result.get("next")
             if next_url is None:
                 raise StopIteration
-            self.result = self.api._request('GET', next_url)
+            self.result = self.api._request("GET", next_url)
         try:
-            item = self.result.get('results', [])[self.index]
+            item = self.result.get("results", [])[self.index]
         except IndexError:
             raise StopIteration
         self.current += 1
@@ -50,18 +49,17 @@ class APIResultSet(object):
 
     @property
     def index(self):
-        return self.current - self.result.get('offset')
+        return self.current - self.result.get("offset")
 
     def __len__(self):
-        return self.result.get('total')
+        return self.result.get("total")
 
     def __repr__(self):
-        return '<APIResultSet(%r, %r)>' % (self.url, len(self))
+        return "<APIResultSet(%r, %r)>" % (self.url, len(self))
 
 
 class EntityResultSet(APIResultSet):
-
-    def __init__(self, api: 'AlephAPI', url: str, publisher: bool):
+    def __init__(self, api: "AlephAPI", url: str, publisher: bool):
         super(EntityResultSet, self).__init__(api, url)
         self.publisher = publisher
 
@@ -70,38 +68,43 @@ class EntityResultSet(APIResultSet):
 
 
 class LinkageResultSet(APIResultSet):
-
-    def __init__(self, api: 'AlephAPI', url: str, publisher: bool):
+    def __init__(self, api: "AlephAPI", url: str, publisher: bool):
         super(LinkageResultSet, self).__init__(api, url)
         self.publisher = publisher
 
     def _patch(self, item):
-        entity = ensure_dict(item.get('entity'))
-        item['entity'] = self.api._patch_entity(entity, self.publisher)
+        entity = ensure_dict(item.get("entity"))
+        item["entity"] = self.api._patch_entity(entity, self.publisher)
         return item
 
 
 class AlephAPI(object):
-
-    def __init__(self,
-                 host: Optional[str] = settings.HOST,
-                 api_key: Optional[str] = settings.API_KEY,
-                 session_id: Optional[str] = None,
-                 retries: int = settings.MAX_TRIES):
+    def __init__(
+        self,
+        host: Optional[str] = settings.HOST,
+        api_key: Optional[str] = settings.API_KEY,
+        session_id: Optional[str] = None,
+        retries: int = settings.MAX_TRIES,
+    ):
 
         if not host:
-            raise AlephException('No host environment variable found')
-        self.base_url = urljoin(host, '/api/2/')
+            raise AlephException("No host environment variable found")
+        self.base_url = urljoin(host, "/api/2/")
         self.retries = retries
         session_id = session_id or str(uuid.uuid4())
         self.session: Session = Session()
-        self.session.headers['X-Aleph-Session'] = session_id
-        self.session.headers['User-Agent'] = 'alephclient/%s' % VERSION
+        self.session.headers["X-Aleph-Session"] = session_id
+        self.session.headers["User-Agent"] = "alephclient/%s" % VERSION
         if api_key is not None:
-            self.session.headers['Authorization'] = 'ApiKey %s' % api_key
+            self.session.headers["Authorization"] = "ApiKey %s" % api_key
 
-    def _make_url(self, path: str, query: Optional[str] = None,
-                  filters: Optional[List] = None, **params):
+    def _make_url(
+        self,
+        path: str,
+        query: Optional[str] = None,
+        filters: Optional[List] = None,
+        **params,
+    ):
         """Construct the target url from given args"""
         url = self.base_url + path
         if query:
@@ -110,35 +113,35 @@ class AlephAPI(object):
             for key, val in filters:
                 params["filter:" + key] = val
         if len(params):
-            url = url + '?' + urlencode(params)
+            url = url + "?" + urlencode(params)
         return url
 
-    def _patch_entity(self, entity: Dict,
-                      publisher: bool,
-                      collection: Optional[Dict] = None):
+    def _patch_entity(
+        self, entity: Dict, publisher: bool, collection: Optional[Dict] = None
+    ):
         """Add extra properties from context to the given entity."""
-        properties: Dict = entity.get('properties', {})
-        collection_: Dict = collection or entity.get('collection') or {}
-        links: Dict = entity.get('links', {})
-        api_url = links.get('self')
+        properties: Dict = entity.get("properties", {})
+        collection_: Dict = collection or entity.get("collection") or {}
+        links: Dict = entity.get("links", {})
+        api_url = links.get("self")
         if api_url is None:
-            api_url = 'entities/%s' % entity.get('id')
+            api_url = "entities/%s" % entity.get("id")
             api_url = self._make_url(api_url)
-        prop_push(properties, 'alephUrl', api_url)
+        prop_push(properties, "alephUrl", api_url)
 
         if publisher:
             # Context: setting the original publisher or collection
             # label can help make the data more traceable when merging
             # data from multiple sources.
-            publisher_label = collection_.get('label')
-            publisher_label = collection_.get('publisher', publisher_label)
-            prop_push(properties, 'publisher', publisher_label)
+            publisher_label = collection_.get("label")
+            publisher_label = collection_.get("publisher", publisher_label)
+            prop_push(properties, "publisher", publisher_label)
 
-            publisher_url = collection_.get('links', {}).get('ui')
-            publisher_url = collection_.get('publisher_url', publisher_url)
-            prop_push(properties, 'publisherUrl', publisher_url)
+            publisher_url = collection_.get("links", {}).get("ui")
+            publisher_url = collection_.get("publisher_url", publisher_url)
+            prop_push(properties, "publisherUrl", publisher_url)
 
-        entity['properties'] = properties
+        entity["properties"] = properties
         return entity
 
     def _request(self, method: str, url: str, **kwargs) -> Dict:
@@ -158,61 +161,83 @@ class AlephAPI(object):
             return response.json()
         return {}
 
-    def search(self, query: str, schema: Optional[str] = None,
-               schemata: Optional[str] = None,
-               filters: Optional[List] = None,
-               publisher: bool = False) -> 'EntityResultSet':
+    def search(
+        self,
+        query: str,
+        schema: Optional[str] = None,
+        schemata: Optional[str] = None,
+        filters: Optional[List] = None,
+        publisher: bool = False,
+    ) -> "EntityResultSet":
         """Conduct a search and return the search results."""
         filters_list: List = ensure_list(filters)
         if schema is not None:
-            filters_list.append(('schema', schema))
+            filters_list.append(("schema", schema))
         if schemata is not None:
-            filters_list.append(('schemata', schemata))
+            filters_list.append(("schemata", schemata))
         if schema is None and schemata is None:
-            filters_list.append(('schemata', 'Thing'))
-        url = self._make_url('entities', query=query, filters=filters_list)
+            filters_list.append(("schemata", "Thing"))
+        url = self._make_url("entities", query=query, filters=filters_list)
         return EntityResultSet(self, url, publisher)
 
     def get_collection(self, collection_id: str) -> Dict:
         """Get a single collection by ID (not foreign ID!)."""
-        url = self._make_url(f'collections/{collection_id}')
-        return self._request('GET', url)
+        url = self._make_url(f"collections/{collection_id}")
+        return self._request("GET", url)
+
+    def delete_collection(self, collection_id: str):
+        """Delete a collection by ID"""
+        url = self._make_url(f"collections/{collection_id}")
+        return self._request("DELETE", url)
+
+    def delete_collection_by_foreign_id(self, foreign_id: str):
+        """Delete a collection by ID"""
+        if foreign_id is None:
+            return None
+        filters = [("foreign_id", foreign_id)]
+        for coll in self.filter_collections(filters=filters):
+            self.delete_collection(col1.get("id"))
 
     def get_entity(self, entity_id: str, publisher: bool = False) -> Dict:
         """Get a single entity by ID."""
-        url = self._make_url(f'entities/{entity_id}')
-        entity = self._request('GET', url)
+        url = self._make_url(f"entities/{entity_id}")
+        entity = self._request("GET", url)
         return self._patch_entity(entity, publisher)
 
     def get_collection_by_foreign_id(self, foreign_id: str) -> Optional[Dict]:
         """Get a dict representing a collection based on its foreign ID."""
         if foreign_id is None:
             return None
-        filters = [('foreign_id', foreign_id)]
+        filters = [("foreign_id", foreign_id)]
         for coll in self.filter_collections(filters=filters):
             return coll
         return None
 
-    def load_collection_by_foreign_id(self, foreign_id: str,
-                                      config: Optional[Dict] = None) -> Dict:
-        """Get a collection by its foreign ID, or create one."""
+    def load_collection_by_foreign_id(
+            self, foreign_id: str, config: Optional[Dict] = None, clear: bool = False
+    ) -> Dict:
+        """Get a collection by its foreign ID, or create one. Setting clear will clear any found collection"""
         collection = self.get_collection_by_foreign_id(foreign_id)
         if collection is not None:
-            return collection
+            if not clear:
+                return collection
+            self.delete_collection(collection.get('id'))
 
         config_: Dict = ensure_dict(config)
-        return self.create_collection({
-            'foreign_id': foreign_id,
-            'label': config_.get('label', foreign_id),
-            'casefile': config_.get('casefile', False),
-            'category': config_.get('category', 'other'),
-            'languages': config_.get('languages', []),
-            'summary': config_.get('summary', ''),
-        })
+        return self.create_collection(
+            {
+                "foreign_id": foreign_id,
+                "label": config_.get("label", foreign_id),
+                "casefile": config_.get("casefile", False),
+                "category": config_.get("category", "other"),
+                "languages": config_.get("languages", []),
+                "summary": config_.get("summary", ""),
+            }
+        )
 
-    def filter_collections(self, query: str = None,
-                           filters: Optional[List] = None,
-                           **kwargs) -> 'APIResultSet':
+    def filter_collections(
+        self, query: str = None, filters: Optional[List] = None, **kwargs
+    ) -> "APIResultSet":
         """Filter collections for the given query and/or filters.
 
         params
@@ -223,8 +248,7 @@ class AlephAPI(object):
         """
         if not query and not filters:
             raise ValueError("One of query or filters is required")
-        url = self._make_url("collections", query=query,
-                             filters=filters, **kwargs)
+        url = self._make_url("collections", query=query, filters=filters, **kwargs)
         return APIResultSet(self, url)
 
     def create_collection(self, data: Dict) -> Dict:
@@ -261,10 +285,13 @@ class AlephAPI(object):
         url = self._make_url(f"collections/{collection_id}/mapping")
         return self._request("PUT", url, json=mapping)
 
-    def stream_entities(self, collection: Optional[Dict] = None,
-                        include: Optional[List] = None,
-                        schema: Optional[str] = None,
-                        publisher: bool = False) -> Iterator[Dict]:
+    def stream_entities(
+        self,
+        collection: Optional[Dict] = None,
+        include: Optional[List] = None,
+        schema: Optional[str] = None,
+        publisher: bool = False,
+    ) -> Iterator[Dict]:
         """Iterate over all entities in the given collection.
 
         params
@@ -272,28 +299,29 @@ class AlephAPI(object):
         collection_id: id of the collection to stream
         include: an array of fields from the index to include.
         """
-        url = self._make_url('entities/_stream')
+        url = self._make_url("entities/_stream")
         if collection is not None:
-            collection_id = collection.get('id')
+            collection_id = collection.get("id")
             url = f"collections/{collection_id}/_stream"
             url = self._make_url(url)
-        params = {'include': include, 'schema': schema}
+        params = {"include": include, "schema": schema}
         try:
             res = self.session.get(url, params=params, stream=True)
             res.raise_for_status()
             for entity in res.iter_lines():
                 entity = json.loads(entity)
-                yield self._patch_entity(entity,
-                                         publisher=publisher,
-                                         collection=collection)
+                yield self._patch_entity(
+                    entity, publisher=publisher, collection=collection
+                )
         except RequestException as exc:
             raise AlephException(exc)
 
-    def _bulk_chunk(self, collection_id: str, chunk: List, force: bool = False,
-                    unsafe: bool = False):
+    def _bulk_chunk(
+        self, collection_id: str, chunk: List, force: bool = False, unsafe: bool = False
+    ):
         for attempt in count(1):
             url = self._make_url(f"collections/{collection_id}/_bulk")
-            params = {'unsafe': unsafe}
+            params = {"unsafe": unsafe}
             try:
                 response = self.session.post(url, json=chunk, params=params)
                 response.raise_for_status()
@@ -307,8 +335,9 @@ class AlephAPI(object):
                     return
                 backoff(ae, attempt)
 
-    def write_entities(self, collection_id: str, entities: Iterable,
-                       chunk_size: int = 1000, **kw):
+    def write_entities(
+        self, collection_id: str, entities: Iterable, chunk_size: int = 1000, **kw
+    ):
         """Create entities in bulk via the API, in the given
         collection.
 
@@ -319,7 +348,7 @@ class AlephAPI(object):
         """
         chunk = []
         for entity in entities:
-            if hasattr(entity, 'to_dict'):
+            if hasattr(entity, "to_dict"):
                 entity = entity.to_dict()
             chunk.append(entity)
             if len(chunk) >= chunk_size:
@@ -328,30 +357,39 @@ class AlephAPI(object):
         if len(chunk):
             self._bulk_chunk(collection_id, chunk, **kw)
 
-    def match(self, entity: Dict, collection_ids: Optional[str] = None,
-              url: str = None, publisher: bool = False) -> Iterator[List]:
+    def match(
+        self,
+        entity: Dict,
+        collection_ids: Optional[str] = None,
+        url: str = None,
+        publisher: bool = False,
+    ) -> Iterator[List]:
         """Find similar entities given a sample entity."""
-        params = {'collection_ids': ensure_list(collection_ids)}
+        params = {"collection_ids": ensure_list(collection_ids)}
         if url is None:
-            url = self._make_url('match')
+            url = self._make_url("match")
         try:
             response = self.session.post(url, json=entity, params=params)
             response.raise_for_status()
-            for result in response.json().get('results', []):
+            for result in response.json().get("results", []):
                 yield self._patch_entity(result, publisher=publisher)
         except RequestException as exc:
             raise AlephException(exc)
 
-    def linkages(self, context_ids: Optional[List] = None,
-                 publisher: bool = False) -> 'APIResultSet':
+    def linkages(
+        self, context_ids: Optional[List] = None, publisher: bool = False
+    ) -> "APIResultSet":
         """Stream all linkages within the given role contexts."""
-        filters = [('context_id', c) for c in ensure_list(context_ids)]
-        url = self._make_url('linkages', filters=filters)
+        filters = [("context_id", c) for c in ensure_list(context_ids)]
+        url = self._make_url("linkages", filters=filters)
         return LinkageResultSet(self, url, publisher=publisher)
 
-    def ingest_upload(self, collection_id: str,
-                      file_path: Optional[Path] = None,
-                      metadata: Optional[Dict] = None) -> Dict:
+    def ingest_upload(
+        self,
+        collection_id: str,
+        file_path: Optional[Path] = None,
+        metadata: Optional[Dict] = None,
+    ) -> Dict:
         """
         Create an empty folder in a collection or upload a document to it
 
@@ -371,13 +409,15 @@ class AlephAPI(object):
 
         for attempt in count(1):
             try:
-                with file_path.open('rb') as fh:
+                with file_path.open("rb") as fh:
                     # use multipart encoder to allow uploading very large files
-                    m = MultipartEncoder(fields={
-                        'meta': json.dumps(metadata),
-                        'file': (file_path.name, fh, MIME)
-                    })
-                    headers = {'Content-Type': m.content_type}
+                    m = MultipartEncoder(
+                        fields={
+                            "meta": json.dumps(metadata),
+                            "file": (file_path.name, fh, MIME),
+                        }
+                    )
+                    headers = {"Content-Type": m.content_type}
                     return self._request("POST", url, data=m, headers=headers)
             except AlephException as ae:
                 if not ae.transient or attempt > self.retries:

--- a/alephclient/api.py
+++ b/alephclient/api.py
@@ -214,14 +214,14 @@ class AlephAPI(object):
         return None
 
     def load_collection_by_foreign_id(
-            self, foreign_id: str, config: Optional[Dict] = None, clear: bool = False
+        self, foreign_id: str, config: Optional[Dict] = None, clear: bool = False
     ) -> Dict:
         """Get a collection by its foreign ID, or create one. Setting clear will clear any found collection"""
         collection = self.get_collection_by_foreign_id(foreign_id)
         if collection is not None:
             if not clear:
                 return collection
-            self.delete_collection(collection.get('id'))
+            self.delete_collection(collection.get("id"))
 
         config_: Dict = ensure_dict(config)
         return self.create_collection(

--- a/alephclient/api.py
+++ b/alephclient/api.py
@@ -15,28 +15,29 @@ from alephclient.errors import AlephException
 from alephclient.util import backoff, prop_push
 
 log = logging.getLogger(__name__)
-MIME = "application/octet-stream"
-VERSION = pkg_resources.get_distribution("alephclient").version
+MIME = 'application/octet-stream'
+VERSION = pkg_resources.get_distribution('alephclient').version
 
 
 class APIResultSet(object):
-    def __init__(self, api: "AlephAPI", url: str):
+
+    def __init__(self, api: 'AlephAPI', url: str):
         self.api = api
         self.url = url
         self.current = 0
-        self.result = self.api._request("GET", self.url)
+        self.result = self.api._request('GET', self.url)
 
     def __iter__(self):
         return self
 
     def __next__(self):
-        if self.index >= self.result.get("limit"):
-            next_url = self.result.get("next")
+        if self.index >= self.result.get('limit'):
+            next_url = self.result.get('next')
             if next_url is None:
                 raise StopIteration
-            self.result = self.api._request("GET", next_url)
+            self.result = self.api._request('GET', next_url)
         try:
-            item = self.result.get("results", [])[self.index]
+            item = self.result.get('results', [])[self.index]
         except IndexError:
             raise StopIteration
         self.current += 1
@@ -49,17 +50,18 @@ class APIResultSet(object):
 
     @property
     def index(self):
-        return self.current - self.result.get("offset")
+        return self.current - self.result.get('offset')
 
     def __len__(self):
-        return self.result.get("total")
+        return self.result.get('total')
 
     def __repr__(self):
-        return "<APIResultSet(%r, %r)>" % (self.url, len(self))
+        return '<APIResultSet(%r, %r)>' % (self.url, len(self))
 
 
 class EntityResultSet(APIResultSet):
-    def __init__(self, api: "AlephAPI", url: str, publisher: bool):
+
+    def __init__(self, api: 'AlephAPI', url: str, publisher: bool):
         super(EntityResultSet, self).__init__(api, url)
         self.publisher = publisher
 
@@ -68,43 +70,38 @@ class EntityResultSet(APIResultSet):
 
 
 class LinkageResultSet(APIResultSet):
-    def __init__(self, api: "AlephAPI", url: str, publisher: bool):
+
+    def __init__(self, api: 'AlephAPI', url: str, publisher: bool):
         super(LinkageResultSet, self).__init__(api, url)
         self.publisher = publisher
 
     def _patch(self, item):
-        entity = ensure_dict(item.get("entity"))
-        item["entity"] = self.api._patch_entity(entity, self.publisher)
+        entity = ensure_dict(item.get('entity'))
+        item['entity'] = self.api._patch_entity(entity, self.publisher)
         return item
 
 
 class AlephAPI(object):
-    def __init__(
-        self,
-        host: Optional[str] = settings.HOST,
-        api_key: Optional[str] = settings.API_KEY,
-        session_id: Optional[str] = None,
-        retries: int = settings.MAX_TRIES,
-    ):
+
+    def __init__(self,
+                 host: Optional[str] = settings.HOST,
+                 api_key: Optional[str] = settings.API_KEY,
+                 session_id: Optional[str] = None,
+                 retries: int = settings.MAX_TRIES):
 
         if not host:
-            raise AlephException("No host environment variable found")
-        self.base_url = urljoin(host, "/api/2/")
+            raise AlephException('No host environment variable found')
+        self.base_url = urljoin(host, '/api/2/')
         self.retries = retries
         session_id = session_id or str(uuid.uuid4())
         self.session: Session = Session()
-        self.session.headers["X-Aleph-Session"] = session_id
-        self.session.headers["User-Agent"] = "alephclient/%s" % VERSION
+        self.session.headers['X-Aleph-Session'] = session_id
+        self.session.headers['User-Agent'] = 'alephclient/%s' % VERSION
         if api_key is not None:
-            self.session.headers["Authorization"] = "ApiKey %s" % api_key
+            self.session.headers['Authorization'] = 'ApiKey %s' % api_key
 
-    def _make_url(
-        self,
-        path: str,
-        query: Optional[str] = None,
-        filters: Optional[List] = None,
-        **params,
-    ):
+    def _make_url(self, path: str, query: Optional[str] = None,
+                  filters: Optional[List] = None, **params):
         """Construct the target url from given args"""
         url = self.base_url + path
         if query:
@@ -113,35 +110,35 @@ class AlephAPI(object):
             for key, val in filters:
                 params["filter:" + key] = val
         if len(params):
-            url = url + "?" + urlencode(params)
+            url = url + '?' + urlencode(params)
         return url
 
-    def _patch_entity(
-        self, entity: Dict, publisher: bool, collection: Optional[Dict] = None
-    ):
+    def _patch_entity(self, entity: Dict,
+                      publisher: bool,
+                      collection: Optional[Dict] = None):
         """Add extra properties from context to the given entity."""
-        properties: Dict = entity.get("properties", {})
-        collection_: Dict = collection or entity.get("collection") or {}
-        links: Dict = entity.get("links", {})
-        api_url = links.get("self")
+        properties: Dict = entity.get('properties', {})
+        collection_: Dict = collection or entity.get('collection') or {}
+        links: Dict = entity.get('links', {})
+        api_url = links.get('self')
         if api_url is None:
-            api_url = "entities/%s" % entity.get("id")
+            api_url = 'entities/%s' % entity.get('id')
             api_url = self._make_url(api_url)
-        prop_push(properties, "alephUrl", api_url)
+        prop_push(properties, 'alephUrl', api_url)
 
         if publisher:
             # Context: setting the original publisher or collection
             # label can help make the data more traceable when merging
             # data from multiple sources.
-            publisher_label = collection_.get("label")
-            publisher_label = collection_.get("publisher", publisher_label)
-            prop_push(properties, "publisher", publisher_label)
+            publisher_label = collection_.get('label')
+            publisher_label = collection_.get('publisher', publisher_label)
+            prop_push(properties, 'publisher', publisher_label)
 
-            publisher_url = collection_.get("links", {}).get("ui")
-            publisher_url = collection_.get("publisher_url", publisher_url)
-            prop_push(properties, "publisherUrl", publisher_url)
+            publisher_url = collection_.get('links', {}).get('ui')
+            publisher_url = collection_.get('publisher_url', publisher_url)
+            prop_push(properties, 'publisherUrl', publisher_url)
 
-        entity["properties"] = properties
+        entity['properties'] = properties
         return entity
 
     def _request(self, method: str, url: str, **kwargs) -> Dict:
@@ -161,29 +158,25 @@ class AlephAPI(object):
             return response.json()
         return {}
 
-    def search(
-        self,
-        query: str,
-        schema: Optional[str] = None,
-        schemata: Optional[str] = None,
-        filters: Optional[List] = None,
-        publisher: bool = False,
-    ) -> "EntityResultSet":
+    def search(self, query: str, schema: Optional[str] = None,
+               schemata: Optional[str] = None,
+               filters: Optional[List] = None,
+               publisher: bool = False) -> 'EntityResultSet':
         """Conduct a search and return the search results."""
         filters_list: List = ensure_list(filters)
         if schema is not None:
-            filters_list.append(("schema", schema))
+            filters_list.append(('schema', schema))
         if schemata is not None:
-            filters_list.append(("schemata", schemata))
+            filters_list.append(('schemata', schemata))
         if schema is None and schemata is None:
-            filters_list.append(("schemata", "Thing"))
-        url = self._make_url("entities", query=query, filters=filters_list)
+            filters_list.append(('schemata', 'Thing'))
+        url = self._make_url('entities', query=query, filters=filters_list)
         return EntityResultSet(self, url, publisher)
 
     def get_collection(self, collection_id: str) -> Dict:
         """Get a single collection by ID (not foreign ID!)."""
-        url = self._make_url(f"collections/{collection_id}")
-        return self._request("GET", url)
+        url = self._make_url(f'collections/{collection_id}')
+        return self._request('GET', url)
 
     def delete_collection(self, collection_id: str):
         """Delete a collection by ID"""
@@ -200,22 +193,22 @@ class AlephAPI(object):
 
     def get_entity(self, entity_id: str, publisher: bool = False) -> Dict:
         """Get a single entity by ID."""
-        url = self._make_url(f"entities/{entity_id}")
-        entity = self._request("GET", url)
+        url = self._make_url(f'entities/{entity_id}')
+        entity = self._request('GET', url)
         return self._patch_entity(entity, publisher)
 
     def get_collection_by_foreign_id(self, foreign_id: str) -> Optional[Dict]:
         """Get a dict representing a collection based on its foreign ID."""
         if foreign_id is None:
             return None
-        filters = [("foreign_id", foreign_id)]
+        filters = [('foreign_id', foreign_id)]
         for coll in self.filter_collections(filters=filters):
             return coll
         return None
 
-    def load_collection_by_foreign_id(
-        self, foreign_id: str, config: Optional[Dict] = None, clear: bool = False
-    ) -> Dict:
+    def load_collection_by_foreign_id(self, foreign_id: str,
+                                    config: Optional[Dict] = None,
+                                    clear: bool = False) -> Dict:
         """Get a collection by its foreign ID, or create one. Setting clear will clear any found collection"""
         collection = self.get_collection_by_foreign_id(foreign_id)
         if collection is not None:
@@ -224,20 +217,18 @@ class AlephAPI(object):
             self.delete_collection(collection.get("id"))
 
         config_: Dict = ensure_dict(config)
-        return self.create_collection(
-            {
-                "foreign_id": foreign_id,
-                "label": config_.get("label", foreign_id),
-                "casefile": config_.get("casefile", False),
-                "category": config_.get("category", "other"),
-                "languages": config_.get("languages", []),
-                "summary": config_.get("summary", ""),
-            }
-        )
+        return self.create_collection({
+            'foreign_id': foreign_id,
+            'label': config_.get('label', foreign_id),
+            'casefile': config_.get('casefile', False),
+            'category': config_.get('category', 'other'),
+            'languages': config_.get('languages', []),
+            'summary': config_.get('summary', ''),
+        })
 
-    def filter_collections(
-        self, query: str = None, filters: Optional[List] = None, **kwargs
-    ) -> "APIResultSet":
+    def filter_collections(self, query: str = None,
+                           filters: Optional[List] = None,
+                           **kwargs) -> 'APIResultSet':
         """Filter collections for the given query and/or filters.
 
         params
@@ -248,7 +239,8 @@ class AlephAPI(object):
         """
         if not query and not filters:
             raise ValueError("One of query or filters is required")
-        url = self._make_url("collections", query=query, filters=filters, **kwargs)
+        url = self._make_url("collections", query=query,
+                             filters=filters, **kwargs)
         return APIResultSet(self, url)
 
     def create_collection(self, data: Dict) -> Dict:
@@ -285,13 +277,10 @@ class AlephAPI(object):
         url = self._make_url(f"collections/{collection_id}/mapping")
         return self._request("PUT", url, json=mapping)
 
-    def stream_entities(
-        self,
-        collection: Optional[Dict] = None,
-        include: Optional[List] = None,
-        schema: Optional[str] = None,
-        publisher: bool = False,
-    ) -> Iterator[Dict]:
+    def stream_entities(self, collection: Optional[Dict] = None,
+                        include: Optional[List] = None,
+                        schema: Optional[str] = None,
+                        publisher: bool = False) -> Iterator[Dict]:
         """Iterate over all entities in the given collection.
 
         params
@@ -299,29 +288,28 @@ class AlephAPI(object):
         collection_id: id of the collection to stream
         include: an array of fields from the index to include.
         """
-        url = self._make_url("entities/_stream")
+        url = self._make_url('entities/_stream')
         if collection is not None:
-            collection_id = collection.get("id")
+            collection_id = collection.get('id')
             url = f"collections/{collection_id}/_stream"
             url = self._make_url(url)
-        params = {"include": include, "schema": schema}
+        params = {'include': include, 'schema': schema}
         try:
             res = self.session.get(url, params=params, stream=True)
             res.raise_for_status()
             for entity in res.iter_lines():
                 entity = json.loads(entity)
-                yield self._patch_entity(
-                    entity, publisher=publisher, collection=collection
-                )
+                yield self._patch_entity(entity,
+                                         publisher=publisher,
+                                         collection=collection)
         except RequestException as exc:
             raise AlephException(exc)
 
-    def _bulk_chunk(
-        self, collection_id: str, chunk: List, force: bool = False, unsafe: bool = False
-    ):
+    def _bulk_chunk(self, collection_id: str, chunk: List, force: bool = False,
+                    unsafe: bool = False):
         for attempt in count(1):
             url = self._make_url(f"collections/{collection_id}/_bulk")
-            params = {"unsafe": unsafe}
+            params = {'unsafe': unsafe}
             try:
                 response = self.session.post(url, json=chunk, params=params)
                 response.raise_for_status()
@@ -335,9 +323,8 @@ class AlephAPI(object):
                     return
                 backoff(ae, attempt)
 
-    def write_entities(
-        self, collection_id: str, entities: Iterable, chunk_size: int = 1000, **kw
-    ):
+    def write_entities(self, collection_id: str, entities: Iterable,
+                       chunk_size: int = 1000, **kw):
         """Create entities in bulk via the API, in the given
         collection.
 
@@ -348,7 +335,7 @@ class AlephAPI(object):
         """
         chunk = []
         for entity in entities:
-            if hasattr(entity, "to_dict"):
+            if hasattr(entity, 'to_dict'):
                 entity = entity.to_dict()
             chunk.append(entity)
             if len(chunk) >= chunk_size:
@@ -357,39 +344,30 @@ class AlephAPI(object):
         if len(chunk):
             self._bulk_chunk(collection_id, chunk, **kw)
 
-    def match(
-        self,
-        entity: Dict,
-        collection_ids: Optional[str] = None,
-        url: str = None,
-        publisher: bool = False,
-    ) -> Iterator[List]:
+    def match(self, entity: Dict, collection_ids: Optional[str] = None,
+              url: str = None, publisher: bool = False) -> Iterator[List]:
         """Find similar entities given a sample entity."""
-        params = {"collection_ids": ensure_list(collection_ids)}
+        params = {'collection_ids': ensure_list(collection_ids)}
         if url is None:
-            url = self._make_url("match")
+            url = self._make_url('match')
         try:
             response = self.session.post(url, json=entity, params=params)
             response.raise_for_status()
-            for result in response.json().get("results", []):
+            for result in response.json().get('results', []):
                 yield self._patch_entity(result, publisher=publisher)
         except RequestException as exc:
             raise AlephException(exc)
 
-    def linkages(
-        self, context_ids: Optional[List] = None, publisher: bool = False
-    ) -> "APIResultSet":
+    def linkages(self, context_ids: Optional[List] = None,
+                 publisher: bool = False) -> 'APIResultSet':
         """Stream all linkages within the given role contexts."""
-        filters = [("context_id", c) for c in ensure_list(context_ids)]
-        url = self._make_url("linkages", filters=filters)
+        filters = [('context_id', c) for c in ensure_list(context_ids)]
+        url = self._make_url('linkages', filters=filters)
         return LinkageResultSet(self, url, publisher=publisher)
 
-    def ingest_upload(
-        self,
-        collection_id: str,
-        file_path: Optional[Path] = None,
-        metadata: Optional[Dict] = None,
-    ) -> Dict:
+    def ingest_upload(self, collection_id: str,
+                      file_path: Optional[Path] = None,
+                      metadata: Optional[Dict] = None) -> Dict:
         """
         Create an empty folder in a collection or upload a document to it
 
@@ -409,15 +387,13 @@ class AlephAPI(object):
 
         for attempt in count(1):
             try:
-                with file_path.open("rb") as fh:
+                with file_path.open('rb') as fh:
                     # use multipart encoder to allow uploading very large files
-                    m = MultipartEncoder(
-                        fields={
-                            "meta": json.dumps(metadata),
-                            "file": (file_path.name, fh, MIME),
-                        }
-                    )
-                    headers = {"Content-Type": m.content_type}
+                    m = MultipartEncoder(fields={
+                        'meta': json.dumps(metadata),
+                        'file': (file_path.name, fh, MIME)
+                    })
+                    headers = {'Content-Type': m.content_type}
                     return self._request("POST", url, data=m, headers=headers)
             except AlephException as ae:
                 if not ae.transient or attempt > self.retries:


### PR DESCRIPTION
This pull request adds the collection deletion endpoints though the methods,

- `api.delete_collection`
- `api.delete_collection_by_foreign_id`

In addition, this adds a `clear` bool parameter to `load_collection_by_foreign_id` to have it clear any found collections before returning a fresh one.

Lastly, my formatter (`black`) did some extra pep8 formatting to the API. I'd be happy to revert that. It's very... errr... opinionated.