### PR TITLE
Fix incomplete reads for stream_entities

### DIFF
--- a/alephclient/api.py
+++ b/alephclient/api.py
@@ -313,7 +313,7 @@ class AlephAPI(object):
         try:
             res = self.session.get(url, params=params, stream=True)
             res.raise_for_status()
-            for entity in res.iter_lines():
+            for entity in res.iter_lines(chunk_size=None):
                 entity = json.loads(entity)
                 yield self._patch_entity(
                     entity, publisher=publisher, collection=collection


### PR DESCRIPTION
I _believe_ we were getting IncompleteRead errors when doing `iter_lines` on a chunked request stream where the read size was smaller than a large entity that was being transmitted. This fix _seems_ to be resolving the issue on my local tests.