### PR TITLE
Feature/make list

### DIFF
--- a/alephclient/api.py
+++ b/alephclient/api.py
@@ -459,8 +459,8 @@ class AlephAPI(object):
     ) -> Dict:
         """Create an EntitySet inside a collection"""
         url = self._make_url("entitysets")
-        params = {"collection_id": collection_id, "type": type, "label": label, "summary": summary, "entities": []}
-        return self._request("POST", url, data=params)
+        data = {"collection_id": collection_id, "type": type, "label": label, "summary": summary, "entities": []}
+        return self._request("POST", url, data=data)
 
     def delete_entityset(self, entityset_id: str, sync: bool = False):
         """Delete an EntitySet by id"""

--- a/alephclient/api.py
+++ b/alephclient/api.py
@@ -449,3 +449,20 @@ class AlephAPI(object):
                     raise ae
                 backoff(ae, attempt)
         return {}
+
+    def create_entityset(
+        self,
+        collection_id: str,
+        type: str,
+        label: str,
+        summary: Optional[str]
+    ) -> Dict:
+        """Create an EntitySet inside a collection"""
+        url = self._make_url("entitysets")
+        params = {"collection_id": collection_id, "type": type, "label": label, "summary": summary, "entities": []}
+        return self._request("POST", url, data=params)
+
+    def delete_entityset(self, entityset_id: str, sync: bool = False):
+        """Delete an EntitySet by id"""
+        url = self._make_url(f"entitysets/{entityset_id}", sync=sync)
+        return self._request("DELETE", url)

--- a/alephclient/cli.py
+++ b/alephclient/cli.py
@@ -257,5 +257,24 @@ def entitysetitems(ctx, outfile, entityset_id):
         raise click.Abort()
 
 
+@cli.command("make-list")
+@click.option("-f", "--foreign-id", required=True, help="foreign_id of the collection")
+@click.option("-o", "--outfile", type=click.File("w"), default="-")
+@click.argument("label")
+@click.option("-s", "--summary", type=str)
+@click.pass_context
+def make_list(ctx, foreign_id, outfile, label, summary):
+    """Create a list"""
+    api = ctx.obj["api"]
+    try:
+        collection_id = _get_id_from_foreign_key(api, foreign_id)
+        res = api.create_entityset(collection_id, "list", label, summary)
+        _write_result(outfile, [res])
+    except AlephException as exc:
+        raise click.ClickException(exc.message)
+    except BrokenPipeError:
+        raise click.Abort()
+
+
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
- add general `create_entityset` and `delete_entityset` to python api
- add specific `make-list` to cli interface, usage:
`alephclient make-list -f <collection_foreign_id> "This is a list" -s "This is the summary text for the list"`