### PR TITLE
Cache document id of uploaded documents and return them later when subsequent uploads are skipped.

### DIFF
--- a/alephclient/memorious.py
+++ b/alephclient/memorious.py
@@ -3,6 +3,7 @@ from pprint import pprint  # noqa
 from banal import clean_dict  # type: ignore
 from typing import Optional
 
+from servicelayer.cache import make_key
 from alephclient import settings
 from alephclient.api import AlephAPI
 from alephclient.util import backoff
@@ -20,6 +21,10 @@ def aleph_emit(context, data):
     foreign_id = data.get("foreign_id", data.get("request_id", source_url))
     if context.skip_incremental(collection_id, foreign_id, content_hash):
         context.log.info("Skip aleph upload: %s", foreign_id)
+        # Fetch document id from cache
+        document_id = context.get_tag(make_key(collection_id, foreign_id, content_hash))
+        data["aleph_id"] = document_id
+        context.emit(data=data, optional=True)
         return
 
     meta = {
@@ -62,6 +67,9 @@ def aleph_emit(context, data):
                 res = api.ingest_upload(collection_id, file_path, meta)
                 document_id = res.get("id")
                 context.log.info("Aleph document entity ID: %s", document_id)
+                context.set_tag(
+                    make_key(collection_id, foreign_id, content_hash), document_id
+                )
                 data["aleph_id"] = document_id
                 data["aleph_document"] = meta
                 data["aleph_collection_id"] = collection_id

--- a/alephclient/memorious.py
+++ b/alephclient/memorious.py
@@ -19,10 +19,10 @@ def aleph_emit(context, data):
     content_hash = data.get("content_hash")
     source_url = data.get("source_url", data.get("url"))
     foreign_id = data.get("foreign_id", data.get("request_id", source_url))
-    if context.skip_incremental(collection_id, foreign_id, content_hash):
+    # Fetch document id from cache
+    document_id = context.get_tag(make_key(collection_id, foreign_id, content_hash))
+    if document_id:
         context.log.info("Skip aleph upload: %s", foreign_id)
-        # Fetch document id from cache
-        document_id = context.get_tag(make_key(collection_id, foreign_id, content_hash))
         data["aleph_id"] = document_id
         context.emit(data=data, optional=True)
         return
@@ -67,6 +67,7 @@ def aleph_emit(context, data):
                 res = api.ingest_upload(collection_id, file_path, meta)
                 document_id = res.get("id")
                 context.log.info("Aleph document entity ID: %s", document_id)
+                # Save the document id in cache for future use
                 context.set_tag(
                     make_key(collection_id, foreign_id, content_hash), document_id
                 )

--- a/alephclient/memorious.py
+++ b/alephclient/memorious.py
@@ -3,7 +3,7 @@ from pprint import pprint  # noqa
 from banal import clean_dict  # type: ignore
 from typing import Optional
 
-from servicelayer.cache import make_key
+from servicelayer.cache import make_key  # type: ignore
 from alephclient import settings
 from alephclient.api import AlephAPI
 from alephclient.util import backoff


### PR DESCRIPTION
I'm working on fixing the eu_eeas_sanctions crawler (https://github.com/alephdata/opensanctions/issues/54). Multiple sanction entries point to a single source document. When creating documentation links one after another, some documentation links are not created because alephclient doesn't emit for skipped uploads. So the pipeline doesn't go to the later stages.

Instead of not emitting on skipped uploads, we should cache the uploaded doc id and emit that when an upload is skipped.