### PR TITLE
Allow multiple filters on the same property

### DIFF
--- a/alephclient/api.py
+++ b/alephclient/api.py
@@ -109,12 +109,13 @@ class AlephAPI(object):
         url = self.base_url + path
         if query:
             params["q"] = query
+        params_list = list(params.items())
         if filters:
             for key, val in filters:
                 if val is not None:
-                    params["filter:" + key] = val
-        if len(params):
-            params_filter = {k: v for k, v in params.items() if v is not None}
+                    params_list.append(("filter:" + key, val))
+        if len(params_list):
+            params_filter = [(k, v) for k, v in params_list if v is not None]
             url = url + "?" + urlencode(params_filter)
         return url
 


### PR DESCRIPTION
Currently, if I specify multiple filters on the same key, only the last one is applied. This keeps the request's `params` object as a list when folding in filters so we can have multi-values params.

Before:
```python
>>> alephclient._make_url("entities", filters=[('a', 'a',),('a', 'b')])
https://aleph.occrp.org/api/2/entities?filter%3Aa=b
```

After:
```python
>>> alephclient._make_url("entities", filters=[('a', 'a',),('a', 'b')])
https://aleph.occrp.org/api/2/entities?filter%3Aa=a&filter%3Aa=b
```