### PR TITLE
Flag for crawldir to ignore dotfiles/directories

### DIFF
--- a/alephclient/cli.py
+++ b/alephclient/cli.py
@@ -66,6 +66,13 @@ def cli(ctx, host, api_key, retries):
     help="do not index documents after ingest",
 )
 @click.option(
+    "-d",
+    "--nodot",
+    is_flag=True,
+    default=False,
+    help="skip dot files",
+)
+@click.option(
     "-l",
     "--language",
     multiple=True,
@@ -74,13 +81,13 @@ def cli(ctx, host, api_key, retries):
 @click.option("-f", "--foreign-id", required=True, help="foreign_id of the collection")
 @click.argument("path", type=click.Path(exists=True))
 @click.pass_context
-def crawldir(ctx, path, foreign_id, language=None, casefile=False, noindex=False):
+def crawldir(ctx, path, foreign_id, language=None, casefile=False, noindex=False, nodot=False):
     """Crawl a directory recursively and upload the documents in it to a
     collection."""
     try:
         config = {"languages": language, "casefile": casefile}
         api = ctx.obj["api"]
-        crawl_dir(api, path, foreign_id, config, index=not noindex)
+        crawl_dir(api, path, foreign_id, config, index=not noindex, dot=not nodot)
     except AlephException as exc:
         raise click.ClickException(str(exc))
 

--- a/alephclient/cli.py
+++ b/alephclient/cli.py
@@ -67,10 +67,10 @@ def cli(ctx, host, api_key, retries):
 )
 @click.option(
     "-d",
-    "--nodot",
+    "--nojunk",
     is_flag=True,
     default=False,
-    help="skip dot files",
+    help="skip dot files, Thumbs.db and other files that are junk in most cases",
 )
 @click.option(
     "-l",
@@ -81,13 +81,13 @@ def cli(ctx, host, api_key, retries):
 @click.option("-f", "--foreign-id", required=True, help="foreign_id of the collection")
 @click.argument("path", type=click.Path(exists=True))
 @click.pass_context
-def crawldir(ctx, path, foreign_id, language=None, casefile=False, noindex=False, nodot=False):
+def crawldir(ctx, path, foreign_id, language=None, casefile=False, noindex=False, nojunk=False):
     """Crawl a directory recursively and upload the documents in it to a
     collection."""
     try:
         config = {"languages": language, "casefile": casefile}
         api = ctx.obj["api"]
-        crawl_dir(api, path, foreign_id, config, index=not noindex, dot=not nodot)
+        crawl_dir(api, path, foreign_id, config, index=not noindex, nojunk=nojunk)
     except AlephException as exc:
         raise click.ClickException(str(exc))
 

--- a/alephclient/tests/test_tasks.py
+++ b/alephclient/tests/test_tasks.py
@@ -14,7 +14,7 @@ class TestCrawldir(object):
         mocker.patch.object(self.api, "create_collection")
         mocker.patch.object(self.api, "update_collection")
         mocker.patch.object(self.api, "ingest_upload")
-        crawl_dir(self.api, "alephclient/tests/testdata", "test153", {})
+        crawl_dir(self.api, "alephclient/tests/testdata", "test153", {}, True, False)
         self.api.create_collection.assert_called_once_with(
             {
                 "category": "other",
@@ -32,9 +32,9 @@ class TestCrawldir(object):
             self.api, "load_collection_by_foreign_id", return_value={"id": 2}
         )
         mocker.patch.object(self.api, "update_collection")
-        crawl_dir(self.api, "alephclient/tests/testdata", "test153", {})
+        crawl_dir(self.api, "alephclient/tests/testdata", "test153", {}, True, False)
         base_path = os.path.abspath("alephclient/tests/testdata")
-        assert self.api.ingest_upload.call_count == 5
+        assert self.api.ingest_upload.call_count == 6
         expected_calls = [
             mocker.call(
                 2,

--- a/alephclient/tests/test_tasks.py
+++ b/alephclient/tests/test_tasks.py
@@ -14,7 +14,7 @@ class TestCrawldir(object):
         mocker.patch.object(self.api, "create_collection")
         mocker.patch.object(self.api, "update_collection")
         mocker.patch.object(self.api, "ingest_upload")
-        crawl_dir(self.api, "alephclient/tests/testdata", "test153", {}, True, False)
+        crawl_dir(self.api, "alephclient/tests/testdata", "test153", {}, True, True)
         self.api.create_collection.assert_called_once_with(
             {
                 "category": "other",
@@ -32,7 +32,7 @@ class TestCrawldir(object):
             self.api, "load_collection_by_foreign_id", return_value={"id": 2}
         )
         mocker.patch.object(self.api, "update_collection")
-        crawl_dir(self.api, "alephclient/tests/testdata", "test153", {}, True, False)
+        crawl_dir(self.api, "alephclient/tests/testdata", "test153", {}, True, True)
         base_path = os.path.abspath("alephclient/tests/testdata")
         assert self.api.ingest_upload.call_count == 6
         expected_calls = [

--- a/alephclient/tests/testdata/dec/.3.txt
+++ b/alephclient/tests/testdata/dec/.3.txt
@@ -1,0 +1,1 @@
+some OS garbage


### PR DESCRIPTION
You can use the --nodot flag with the crawldir command to ignore OS garbage that you don't want in Aleph, unless
you're working in forensics. Flag is off by default so current behaviour is maintained.