### PR TITLE
Crawldir: use os.scandir and run uploads in parallel

### DIFF
--- a/alephclient/cli.py
+++ b/alephclient/cli.py
@@ -78,16 +78,24 @@ def cli(ctx, host, api_key, retries):
     multiple=True,
     help="language hint: 2-letter language code (ISO 639)",
 )
+@click.option(
+    "-p",
+    "--parallel",
+    default=1,
+	show_default=True,
+	type=click.IntRange(1),
+    help="maximum number of parallel uploads"
+)
 @click.option("-f", "--foreign-id", required=True, help="foreign_id of the collection")
 @click.argument("path", type=click.Path(exists=True))
 @click.pass_context
-def crawldir(ctx, path, foreign_id, language=None, casefile=False, noindex=False, nojunk=False):
+def crawldir(ctx, path, foreign_id, language=None, casefile=False, noindex=False, nojunk=False, parallel=1):
     """Crawl a directory recursively and upload the documents in it to a
     collection."""
     try:
         config = {"languages": language, "casefile": casefile}
         api = ctx.obj["api"]
-        crawl_dir(api, path, foreign_id, config, index=not noindex, nojunk=nojunk)
+        crawl_dir(api, path, foreign_id, config, index=not noindex, nojunk=nojunk, parallel=parallel)
     except AlephException as exc:
         raise click.ClickException(str(exc))
 

--- a/alephclient/crawldir.py
+++ b/alephclient/crawldir.py
@@ -2,8 +2,10 @@ import logging
 import threading
 import re
 import stat
+import os
+from os import PathLike
 from queue import Queue
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import cast, Optional, Dict
 
 from alephclient import settings
@@ -12,7 +14,6 @@ from alephclient.errors import AlephException
 from alephclient.util import backoff
 
 log = logging.getLogger(__name__)
-
 
 class CrawlDirectory(object):
     def __init__(self, api: AlephAPI, collection: Dict, path: Path, index: bool = True, nojunk: bool = False):
@@ -26,34 +27,82 @@ class CrawlDirectory(object):
         self.collection_id = cast(str, collection.get("id"))
         self.root = path
         self.queue: Queue = Queue()
-        self.queue.put((path, None, 1))
+        self.scan_queue: Queue = Queue()
+        if path.is_dir():
+            if not self.is_excluded(path):
+                self.scan_queue.put((path, None))
+        elif not self.is_excluded(path):
+            self.queue.put((path, None))
 
-    def execute(self):
-        while not self.queue.empty():
-            path, parent_id, try_number = self.queue.get()
-            try:
-                self.crawl_path(parent_id, path)
-            except AlephException as exc:
-                if exc.transient and try_number < self.api.retries:
-                    backoff(exc, try_number)
-                    self.queue.put((path, parent_id, try_number + 1))
+    def crawl(self):
+        while not self.scan_queue.empty():
+            path, parent_id = self.scan_queue.get()
+            id = None
+            foreign_id = self.get_foreign_id(path)
+            if foreign_id is not None:
+                id = self.backoff_ingest_upload(path, parent_id, foreign_id)
+            self.scandir(path, id, parent_id)
+            self.scan_queue.task_done()
+
+    def consume(self):
+        while True:
+            path, parent_id = self.queue.get()
+			# None value for path is used as poison, to signal end.
+            if path is None:
+                break
+            self.backoff_ingest_upload(path, parent_id, self.get_foreign_id(path))
+            self.queue.task_done()
+
+    def is_excluded(self, path: PathLike) -> bool:
+        # The exclude pattern is constructed bearing in mind that will
+        # be called using fullmatch.
+        if self.exclude is None:
+            return false
+        if path.is_dir():
+            return self.exclude["d"].fullmatch(path.name)
+        return self.exclude["f"].fullmatch(path.name)
+
+    def scandir(self, path: PathLike, id: str, parent_id: str):
+        with os.scandir(path) as iterator:
+            while True:
+                child = next(iterator, None)
+                if child is None:
+                    break
+                if self.is_excluded(child):
+                    continue
+                if child.is_dir():
+                    # Use a separate scan queue to avoid calling scandir recursively.
+                    self.scan_queue.put((child, id))
                 else:
-                    log.error(exc.message)
-            except Exception:
-                log.exception("Failed [%s]: %s", self.collection_id, path)
-            finally:
-                self.queue.task_done()
+                    self.queue.put((child, id))
 
-    def get_foreign_id(self, path: Path) -> Optional[str]:
+    def get_foreign_id(self, path: PathLike) -> Optional[str]:
         if path == self.root:
             if path.is_dir():
                 return None
             return path.name
-        if self.root in path.parents:
+        path = PurePath(path)
+        if path.is_relative_to(self.root):
             return str(path.relative_to(self.root))
         return None
 
-    def upload_path(self, path: Path, parent_id: str, foreign_id: str) -> str:
+    def backoff_ingest_upload(self, path: PathLike, parent_id: str, foreign_id: str) -> Optional[str]:
+        try_number = 1
+        while True:
+            try:
+                return self.ingest_upload(path, parent_id, foreign_id)
+            except AlephException as err:
+                if err.transient and try_number < self.api.retries:
+                    try_number += 1
+                    backoff(err, try_number)
+                else:
+                    log.error(err.message)
+                    return None
+            except Exception:
+                log.exception("Failed [%s]: %s", self.collection_id, path)
+                return None
+
+    def ingest_upload(self, path: PathLike, parent_id: str, foreign_id: str) -> str:
         metadata = {
             "foreign_id": foreign_id,
             "file_name": path.name,
@@ -62,34 +111,14 @@ class CrawlDirectory(object):
         if parent_id is not None:
             metadata["parent_id"] = parent_id
         result = self.api.ingest_upload(
-            self.collection_id, path, metadata=metadata, index=self.index
+            self.collection_id, path if isinstance(path, Path) else Path(path.path), metadata=metadata, index=self.index
         )
-        if "id" not in result:
+        if "id" not in result and not hasattr(result, "id"):
             raise AlephException("Upload failed")
         return result["id"]
 
-    def crawl_path(self, parent_id: str, path: Path):
-        foreign_id = self.get_foreign_id(path)
-        # A foreign ID will be generated for all paths but the root directory
-        # of an imported folder. For this, we'll just list the directory but
-        # not create a document to reflect the root.
-        if foreign_id is not None:
-            parent_id = self.upload_path(path, parent_id, foreign_id)
-        if path.is_dir():
-            for child in path.iterdir():
-                # The exclude pattern is constructed bearing in mind that will
-                # be called using fullmatch.
-                if self.exclude is not None:
-                    mode = child.stat().st_mode
-                    if stat.S_ISDIR(mode) and self.exclude["d"].fullmatch(child.name):
-                       continue
-                    elif stat.S_ISREG(mode) and self.exclude["f"].fullmatch(child.name):
-                       continue
-                self.queue.put((child, parent_id, 1))
-
-
 def crawl_dir(
-    api: AlephAPI, path: str, foreign_id: str, config: Dict, index: bool = True, nojunk: bool = False
+    api: AlephAPI, path: str, foreign_id: str, config: Dict, index: bool = True, nojunk: bool = False, parallel: int = 1
 ):
     """Crawl a directory and upload its content to a collection
 
@@ -102,14 +131,24 @@ def crawl_dir(
     root = Path(path).resolve()
     collection = api.load_collection_by_foreign_id(foreign_id, config)
     crawler = CrawlDirectory(api, collection, root, index=index, nojunk=nojunk)
-    threads = []
-    for i in range(settings.THREADS):
-        thread = threading.Thread(target=crawler.execute)
-        thread.daemon = True
-        thread.start()
-        threads.append(thread)
+    consumers = []
 
-    # block until all tasks are done
+    # Use one thread to produce using scandir and at least one to consume
+    # files for upload.
+    producer = threading.Thread(target=crawler.crawl, daemon=True)
+    producer.start()
+    for i in range(max(1, parallel)):
+        consumer = threading.Thread(target=crawler.consume, daemon=True)
+        consumer.start()
+        consumers.append(consumer)
+
+    # Block until the producer is done with queueing the tree.
+    producer.join()
+
+    # Block until the file upload queue is drained.
     crawler.queue.join()
-    for thread in threads:
-        thread.join()
+
+    # Block until all file upload queue consumers are done.
+    for consumer in consumers:
+        crawler.queue.put((None, None)) # Poison the queue to signal end.
+        consumer.join()

--- a/alephclient/settings.py
+++ b/alephclient/settings.py
@@ -10,8 +10,5 @@ API_KEY = os.environ.get("MEMORIOUS_ALEPH_API_KEY")
 API_KEY = os.environ.get("ALEPH_API_KEY", API_KEY)
 API_KEY = os.environ.get("ALEPHCLIENT_API_KEY", API_KEY)
 
-THREADS = multiprocessing.cpu_count() * 2
-THREADS = int(os.environ.get("ALEPHCLIENT_THREADS", THREADS))
-TIMEOUT = int(os.environ.get("ALEPHCLIENT_TIMEOUT", 60))
 MAX_TRIES = int(os.environ.get("ALEPHCLIENT_MAX_TRIES", 5))
 MEMORIOUS_RATE_LIMIT = int(os.environ.get("ALEPHCLIENT_MEMORIOUS_RATE_LIMIT", 120))


### PR DESCRIPTION
This is a refactor of the crawldir command that needs review, aiming to fix #26.

 - os.scandir is used instead of listdir, for a big performance improvement on directories containing many thousands of files or subdirectories
- because os.scandir produces DirEntry objects with cached attributes, is_dir and friends don't do additional stats, improving performance if using NFS
- files are queued and uploaded by `--parallel` consumers
- unfortunately, Python 3.6 features have to be used