### PR TITLE
Add load-catalog cli command

### DIFF
--- a/alephclient/load_catalog.py
+++ b/alephclient/load_catalog.py
@@ -1,0 +1,81 @@
+import json
+import logging
+from typing import Any, Dict, Generator, List, Optional, Tuple
+
+import requests
+from banal import ensure_list
+
+from alephclient.api import AlephAPI
+
+log = logging.getLogger(__name__)
+
+EntityData = Dict[str, Any]
+Loader = Tuple[str, Generator[EntityData, None, None]]
+
+MIME_TYPE = "application/json+ftm"
+
+
+def stream_resource(url: str, foreign_id: str) -> Generator[EntityData, None, None]:
+    res = requests.get(url, stream=True)
+    if not res.ok:
+        raise requests.HTTPError(res.status_code)
+
+    for ix, data in enumerate(res.iter_lines()):
+        if ix and ix % 1000 == 0:
+            log.info("[%s] Bulk load entities: %s...", foreign_id, ix)
+        yield json.loads(data)
+
+
+def load_catalog(
+    api: AlephAPI,
+    url: str,
+    exclude_datasets: Optional[List[str]] = [],
+    include_datasets: Optional[List[str]] = [],
+    frequency: Optional[str] = None,
+) -> Generator[Loader, None, None]:
+    res = requests.get(url)
+    if not res.ok:
+        raise requests.HTTPError(res.status_code)
+
+    catalog = res.json()
+    for dataset in catalog["datasets"]:
+        foreign_id = dataset["name"]
+
+        if "type" in dataset and dataset["type"] != "collection":
+            continue
+        if exclude_datasets and foreign_id in exclude_datasets:
+            continue
+        if include_datasets and foreign_id not in include_datasets:
+            continue
+
+        aleph_collection = api.get_collection_by_foreign_id(foreign_id)
+        data = {
+            "label": dataset["title"],
+            "summary": (
+                dataset.get("description", "") + "\n\n" + dataset.get("summary", "")
+            ).strip(),
+            "publisher": dataset.get("publisher", {}).get("name"),
+            "publisher_url": dataset.get("publisher", {}).get("url"),
+            "countries": ensure_list(dataset.get("publisher", {}).get("country")),
+            "data_url": dataset.get("data", {}).get("url"),
+            "category": dataset.get("category", "other"),
+        }
+        if "frequency" in dataset or frequency is not None:
+            data["frequency"] = dataset.get("frequency", frequency)
+
+        if aleph_collection is not None:
+            log.info("[%s] Creating collection ..." % foreign_id)
+            aleph_collection = api.update_collection(
+                aleph_collection["collection_id"], data
+            )
+        else:
+            log.info("[%s] Updating collection metadata ..." % foreign_id)
+            aleph_collection = api.create_collection(
+                {**data, **{"foreign_id": dataset["name"]}}
+            )
+
+        for resource in ensure_list(dataset.get("resources")):
+            if resource["mime_type"] == MIME_TYPE:
+                yield aleph_collection["collection_id"], stream_resource(
+                    resource["url"], foreign_id
+                )

--- a/alephclient/tests/test_load_catalog.py
+++ b/alephclient/tests/test_load_catalog.py
@@ -1,0 +1,21 @@
+from alephclient.api import AlephAPI
+from alephclient.load_catalog import load_catalog
+
+
+class TestLoadCatalog:
+    fake_url = "http://aleph.test/api/2/"
+    catalog_url = "https://data.opensanctions.org/datasets/latest/index.json"
+
+    def setup_method(self, mocker):
+        self.api = AlephAPI(host=self.fake_url, api_key="fake_key")
+
+    def test_load_catalog(self, mocker):
+        mocker.patch.object(self.api, "_request")
+        for collection_id, loader in load_catalog(self.api, self.catalog_url):
+            self.api._request.assert_called_with(
+                "GET", "{}collections/{}".format(self.fake_url, collection_id)
+            )
+            for data in loader:
+                assert isinstance(data, dict)
+                break
+            break


### PR DESCRIPTION
This is a first lay out for a `load-catalog` command.

It accepts an url to a catalog index json and a few options (include/exclude specific datasets), creates or updates the collections metadata and bulk loads the entities into aleph.

A few questions arise:
- should we just safely assume to map dataset names to aleph `foreign_id` ? This could write entities into existing collections with the same `foreign_id` that are originally not meant to be the dataset from the catalog
- do we want more logic (e.g. skip importing for not updated since ...)
- and something like "inspect catalog" to see some metadata without actually importing
- how to handle collections/children?