### PR TITLE
write-entities: nicer progress status

### DIFF
--- a/alephclient/cli.py
+++ b/alephclient/cli.py
@@ -1,6 +1,7 @@
 import json
 import click
 import logging
+import sys
 from pathlib import Path
 
 from alephclient import settings
@@ -296,7 +297,10 @@ def write_entities(
                     return
                 count += 1
                 if count % chunksize == 0:
-                    log.info("[%s] Bulk load entities: %s...", foreign_id, count)
+                    if sys.stdout.isatty():
+                        print(f"\r\x1b[K[{foreign_id}] Bulk load entities: {count:_}...", end='')
+                    else:
+                        log.info(f"[{foreign_id}] Bulk load entities: {count:_}...")
                 yield json.loads(line)
 
         api.write_entities(
@@ -312,6 +316,9 @@ def write_entities(
         raise click.ClickException(exc.message)
     except BrokenPipeError:
         raise click.Abort()
+    finally:
+        if sys.stdout.isatty():
+            print()
 
 
 @cli.command("stream-entities")


### PR DESCRIPTION
This makes two changes to make a progress status a bit nicer:

- Print the number with thousands separator, e.g. "150_000" instead of 150000".

- For interactive terminals it will also replace the current line rather than printing a new one. "\r" moves the cursor to the first column, and "\x1b[K" clears the line. This works on all current terminals ( where "current" means "since the 90s").