### PR TITLE
write-entities: add --investigation

### DIFF
--- a/alephclient/cli.py
+++ b/alephclient/cli.py
@@ -273,6 +273,9 @@ def delete_entity(ctx, entity_id):
 @click.option(
     "--cleaned", is_flag=True, default=False, help="disable server-side validation for all types"
 )
+@click.option(
+    "--investigation", is_flag=True, default=False, help="create an investigation, rather than dataset"
+)
 @click.pass_context
 def write_entities(
     ctx,
@@ -282,12 +285,15 @@ def write_entities(
     chunksize=1000,
     force=False,
     unsafe=False,
-    cleaned=False
+    cleaned=False,
+    investigation=False
 ):
     """Read entities from standard input and index them."""
     api = ctx.obj["api"]
     try:
-        collection = api.load_collection_by_foreign_id(foreign_id)
+        collection = api.load_collection_by_foreign_id(foreign_id, {
+            "casefile": investigation,
+        })
 
         def read_json_stream(stream):
             count = 0


### PR DESCRIPTION
Right now the logic in Aleph is that an admin user always creates a dataset, and a non-admin user always creates an investigation.

With this flag, an admin user can create an investigation.